### PR TITLE
Fix some endpoints that returned 500 on GET with content-type html

### DIFF
--- a/tracks/endpoints_urls.py
+++ b/tracks/endpoints_urls.py
@@ -1,19 +1,17 @@
 from django.conf.urls import patterns, url
 
 from tracks.endpoints import (
-    TrackListAPIView, VoteAPIView,
-    VoteSkipNowPlayingAPIView, InsertTrackAPIView, PlayingStatusAPIView)
+    VoteAPIView, VoteSkipNowPlayingAPIView, ListCreateTrackAPIView,
+    PlayingStatusAPIView)
 
 
 urlpatterns = patterns('',
-    url(r'^tracks/$', TrackListAPIView.as_view(), name='list'),
     url(r'^tracks/(?P<track_id>\d+)/vote/$', VoteAPIView.as_view(),
         name='vote'),
 
     url(r'^tracks/now-playing/voteskip/$', VoteSkipNowPlayingAPIView.as_view(),
         name='now-playing-skip'),
-    url(r'^tracks/(?P<service>.+)/(?P<service_id>.+)/$',
-        InsertTrackAPIView.as_view(), name='insert'),
-    url(r'tracks/change-player-status/$', PlayingStatusAPIView.as_view(),
+    url(r'^tracks/$', ListCreateTrackAPIView.as_view(), name='list-create'),
+    url(r'^tracks/change-player-status/$', PlayingStatusAPIView.as_view(),
         name='change-status'),
 )

--- a/tracks/mixins.py
+++ b/tracks/mixins.py
@@ -51,7 +51,7 @@ class GetTokenMixin(object):
         auth_header = self.request.META.get('HTTP_AUTHORIZATION', '')
         splitted_auth_header = auth_header.split(' ')
 
-        if len(splitted_auth_header):
+        if any(splitted_auth_header):
             __, token = splitted_auth_header
         else:
             token = None

--- a/tracks/serializers.py
+++ b/tracks/serializers.py
@@ -11,7 +11,7 @@ class VoteSerializer(serializers.ModelSerializer):
 
 
 class TrackSerializer(serializers.ModelSerializer):
-    votes = VoteSerializer(many=True)
+    votes = VoteSerializer(many=True, read_only=True)
     voters = serializers.SerializerMethodField()
     skippers = serializers.SerializerMethodField()
 
@@ -19,6 +19,7 @@ class TrackSerializer(serializers.ModelSerializer):
         model = Track
         fields = ('id', 'service_id', 'artist', 'title',
                   'votes', 'voters', 'skippers', 'service')
+        read_only_fields = ('id', 'artist', 'title')
 
     def get_voters(self, track):
         return list(track.votes.values_list('token', flat=True))
@@ -32,6 +33,12 @@ class TrackSerializer(serializers.ModelSerializer):
         rep['left_to_skip'] = (len(rep['votes']) + 1 -
                                len(rep['skippers']))
         return rep
+
+    def create(self, validated_data):
+        establishment = self.context['establishment']
+        return Track.fetch_and_save_track(
+            establishment=establishment, service=validated_data['service'],
+            service_id=validated_data['service_id'])
 
 
 class TrackListSerializer(serializers.Serializer):

--- a/tracks/static/js/vote.js
+++ b/tracks/static/js/vote.js
@@ -69,7 +69,8 @@
       var insertTrack = function (identifier) {
         var service = identifier.split(';')[0];
         var service_id = identifier.split(';')[1];
-        return $http.post(API_URL + '/tracks/' + service + '/' + service_id + '/');
+        return $http.post(API_URL + '/tracks/',
+                          {'service': service, 'service_id': service_id});
       };
 
       var insertVote = function (track_id) {


### PR DESCRIPTION
Some endpoints raised 500 when accessed via DRF browseable API.
Made List/Create tracks more restful.
